### PR TITLE
added feature to let action bot push eslint fixes in repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,22 @@ jobs:
           cache: "npm"
       - run: npm i
 
-      - name: Eslint
+      - name: Fix issues with Eslint
+        run: npm run eslint-fix
+
+      - name: Commit changes
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+          git commit -am "fixed eslint issues" || true
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+      
+      - name: Eslint check again
         run: npm run eslint
 
       - name: Run test

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc -noEmit -skipLibCheck -p ./tsconfig.build.json && node utils/esbuild.config.mjs production",
     "version": "node utils/version-bump.mjs && git add manifest.json versions.json",
     "test": "jest",
+    "eslint-fix": "eslint --fix src ; exit 0",
     "eslint": "eslint src",
     "pretty": "prettier --write *.ts *.json src test --ignore-path package-lock.json"
   },


### PR DESCRIPTION
Added functionally of the [issue](https://github.com/snezhig/obsidian-front-matter-title/issues/128).
When there are EsLint style issues those are fixed and pushed into the repo.
What needs to be done is to enable that the GH Actions Bot can push those changes, like I mentioned in the Issue, in the Settings under Actions > General - Workflow permissions Read and Write permissions so that the GH Actions Bot can actually push the changes. Before those changes are not done, the CI won´t work.