### PR TITLE
[do NOT merge] put 'id' from front-matter into the right side of FileExplorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ data.json
 var
 
 *.js
+help.sh

--- a/config/services/feature.config.ts
+++ b/config/services/feature.config.ts
@@ -34,9 +34,10 @@ import AliasConfig from "@src/Feature/Alias/AliasConfig";
 import { KeyStorageInterface } from "../../src/Storage/Interfaces";
 import { SettingsType } from "../../src/Settings/SettingsType";
 import { Feature } from "../../src/Enum";
-import { TFileExplorerItem } from "obsidian";
+import {MetadataCacheExt, TFileExplorerItem} from "obsidian";
 import { ResolverInterface } from "../../src/Resolver/Interfaces";
 import { ExplorerFileItemMutator } from "../../src/Feature/Explorer/ExplorerFileItemMutator";
+import {MetadataCacheFactory} from "@config/inversify.factory.types";
 
 export default (container: Container) => {
     container.bind(SI["feature:service"]).to(FeatureService).inSingletonScope();
@@ -102,5 +103,8 @@ export default (container: Container) => {
             return c.container.get<KeyStorageInterface<SettingsType>>(SI["settings:storage"]).get('features').get(feature).value()
         }).when(() => true)
 
-    container.bind(SI["feature:explorer:file_mutator:factory"]).toFunction((item: TFileExplorerItem, resolver: ResolverInterface) => new ExplorerFileItemMutator(item, resolver))
+    container.bind(SI["feature:explorer:file_mutator:factory"])
+        .toFunction((item: TFileExplorerItem, resolver: ResolverInterface, factory: MetadataCacheFactory<MetadataCacheExt>) => {
+            return new ExplorerFileItemMutator(item, resolver, factory);
+        })
 };

--- a/src/Feature/Explorer/ExplorerFileItemMutator.ts
+++ b/src/Feature/Explorer/ExplorerFileItemMutator.ts
@@ -1,10 +1,14 @@
-import { TFileExplorerItem } from "obsidian";
+import {MetadataCacheExt, TFile, TFileExplorerItem, TFolder} from "obsidian";
 import { ResolverInterface } from "../../Resolver/Interfaces";
 import { injectable } from "inversify";
+import {MetadataCacheFactory} from "@config/inversify.factory.types";
 
 @injectable()
 export class ExplorerFileItemMutator {
-    constructor(private readonly item: TFileExplorerItem, private readonly resolver: ResolverInterface) {
+    constructor(private readonly item: TFileExplorerItem,
+                private readonly resolver: ResolverInterface,
+                private readonly factory: MetadataCacheFactory<MetadataCacheExt> ) {
+
         item.updateTitle = this.updateTitle.bind(this);
         item.startRename = this.startRename.bind(this);
     }
@@ -12,15 +16,61 @@ export class ExplorerFileItemMutator {
     private getProto(): TFileExplorerItem {
         return Object.getPrototypeOf(this.item);
     }
+
+    /**
+     * - tree-item
+     *   - tree-item-self             <-- selfEl
+     *     - tree-item-inner: title   <-- innerEl
+     *     - nav-file-tag             <-- file tag, eg. png, svg
+     *   - tree-item-children         <-- children nodes
+     * @private
+     */
     private updateTitle() {
         this.getProto().updateTitle.call(this.item);
         const title = this.resolver.resolve(this.item.file.path);
         title?.length > 0 && this.item.innerEl.setText(title);
+
+        this.hook(this.item.file);
     }
 
     private startRename() {
         this.item.innerEl.setText(this.item.getTitle());
-        return this.getProto().startRename.call(this.item);
+        this.getProto().startRename.call(this.item);
+
+        this.hook(this.item.file);
+    }
+
+    private hook(file: TFile | TFolder) {
+        const cache = this.factory();
+        if (file instanceof TFile) {
+            if (file.extension == 'md' && !file.basename.contains(".excalidraw.md")) {
+                this.createOrUpdateExtraDiv(cache, file);
+            }
+        }
+    }
+
+    private createOrUpdateExtraDiv(cache: MetadataCacheExt, file: TFile) {
+        const fileCache = cache.getFileCache(file);
+        const id = fileCache?.frontmatter?.ID;
+        const selfEl = this.item.selfEl;
+
+        if (id) {
+            const extras = selfEl.findAll(".tree-item-extra");
+            if (!extras) {
+                // create
+                selfEl.createEl("div", {text: id, cls: "tree-item-extra nav-file-title-content"});
+            } else if (extras.length == 1) {
+                // update
+                let single = extras[0];
+                single.innerText = id;
+            } else {
+                extras.forEach((v) => {
+                    console.error(`too much nodes for ${id} - ${v.id}`)
+                    v.remove();
+                })
+                selfEl.createEl("div", {text: id, cls: "tree-item-extra nav-file-title-content"});
+            }
+        }
     }
     public destroy() {
         this.item.updateTitle = this.getProto().updateTitle;

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,32 @@
+.nav-file-title {
+    display: flex;
+    /*flex-direction: column;*/         /* vertical layout */
+	justify-content: space-between;     /* horizontal layout */
+}
+
+.nav-file-title-content, .nav-folder-title-content {
+    overflow: revert;
+}
+
+.tree-item-extra {
+    order: 99;
+    opacity: 60%;
+    align-self: center;
+    background-color: var(--background-modifier-hover);
+    border-radius: var(--radius-s);
+    color: var(--nav-file-tag) !important;
+    font-family: var(--font-monospace), Menlo, monospace;
+    /*font-size: 9px;*/
+    font-size: var(--font-smallest);
+    font-weight: var(--font-semibold);
+    letter-spacing: 0.05em;
+    line-height: var(--line-height-normal);
+    margin-left: var(--size-2-3);
+    padding: 0 var(--size-4-1);
+}
+
+/* attachment files: png and others */
+/*
+.nav-file-tag {
+}
+*/


### PR DESCRIPTION
I found some way to fulfill my feature request (#174 ). 
But to be honest I'm not familiar with typescript and obsidian plugin development at all.
The PR is not production-ready, just a MVP Demo.

The front-matter data and Explorer's effect are shown as below: 

<img width="436" alt="image" src="https://github.com/snezhig/obsidian-front-matter-title/assets/56830/150852c1-44c1-471e-9e85-2ff40ccc4508">

```yaml
---
ID: 221130-173626
---
```
