### PR TITLE
Add file to v2 processor

### DIFF
--- a/src/Components/Processor/FunctionV2Processor.ts
+++ b/src/Components/Processor/FunctionV2Processor.ts
@@ -2,21 +2,27 @@ import { inject, injectable } from "inversify";
 import ProcessorInterface from "./Interfaces";
 import SI from "../../../config/inversify.types";
 import { FunctionV2ObjArg, ProcessorTypes } from "@src/Components/Processor/ProcessorUtils";
+import { App } from "obsidian";
 
 @injectable()
 export default class FunctionV2Processor implements ProcessorInterface {
     private readonly func: Function | null;
+    private readonly app: App;
 
     constructor(
         @inject(SI["processor:args"])
-        args: string[]
+        args: string[],
+        @inject(SI["obsidian:app"])
+        app: App
     ) {
-        this.func = args?.[0] ? new Function("obj", args[0]) : null;
+        this.app = app;
+        this.func = args?.[0] ? new Function("obj", "file", args[0]) : null;
     }
 
     process(value: string): string {
         const obj = JSON.parse(value) as FunctionV2ObjArg;
-        return this.func?.(obj) ?? obj.title;
+        const file = this.app.vault.getFileByPath(obj.path);
+        return this.func?.(obj, file) ?? obj.title;
     }
 
     getType(): ProcessorTypes {


### PR DESCRIPTION
In response to #215 , here is a possible solution for providing access to the TFile in the V2 processor.

Like others in that thread, what I really need is the frontmatter in particular, but I believe others may find it more useful to have the whole TFile itself, which is why I did it this way.

If there is no need for the TFile, we could instead just pass the frontmatter object along. I'd be happy to update the PR to do that.

The way this is currently written, you could do this:

```javascript
const fm = app.metadataCache.getFileCache(file).frontmatter;
return fm["someField"] + fm["someOtherField"];
```