### PR TITLE
Fix tab title is lost after switching tabs

### DIFF
--- a/src/Feature/Tab/TabManager.ts
+++ b/src/Feature/Tab/TabManager.ts
@@ -89,16 +89,14 @@ export default class TabManager extends AbstractManager {
             Object.getPrototypeOf(leaf),
             "getDisplayText",
             this,
-            function (self2, _, vanilla) {
+            function (self, _, vanilla) {
                 const filePath = this.view == null
                     ? null
                     : this.view.file != null
                         ? this.view.file.path
                         : (this.view.getState() || {}).file;
 
-                let title = filePath ? self2.resolver.resolve(filePath) : vanilla.call(this);
-
-                return title;
+                return filePath ? self.resolver.resolve(filePath) : vanilla.call(this);
             }
         );
 

--- a/src/Feature/Tab/TabManager.ts
+++ b/src/Feature/Tab/TabManager.ts
@@ -90,12 +90,13 @@ export default class TabManager extends AbstractManager {
             "getDisplayText",
             this,
             function (self, _, vanilla) {
-                const filePath = this.view == null
-                    ? null
-                    : this.view.file != null
+                const filePath =
+                    this.view == null
+                        ? null
+                        : this.view.file != null
                         ? this.view.file.path
                         : (this.view.getState() ?? {}).file;
-                
+
                 if (filePath != null) {
                     return self.resolver.resolve(filePath) ?? vanilla.call(this);
                 }

--- a/src/Feature/Tab/TabManager.ts
+++ b/src/Feature/Tab/TabManager.ts
@@ -90,6 +90,7 @@ export default class TabManager extends AbstractManager {
             "getDisplayText",
             this,
             function (self, _, vanilla) {
+                /* eslint-disable eqeqeq */
                 const filePath =
                     this.view == null
                         ? null
@@ -102,6 +103,7 @@ export default class TabManager extends AbstractManager {
                 }
 
                 return vanilla.call(this);
+                /* eslint-enable eqeqeq */
             }
         );
 

--- a/src/Feature/Tab/TabManager.ts
+++ b/src/Feature/Tab/TabManager.ts
@@ -94,9 +94,13 @@ export default class TabManager extends AbstractManager {
                     ? null
                     : this.view.file != null
                         ? this.view.file.path
-                        : (this.view.getState() || {}).file;
+                        : (this.view.getState() ?? {}).file;
+                
+                if (filePath != null) {
+                    return self.resolver.resolve(filePath) ?? vanilla.call(this);
+                }
 
-                return filePath ? self.resolver.resolve(filePath) : vanilla.call(this);
+                return vanilla.call(this);
             }
         );
 


### PR DESCRIPTION
Hi,

Often after switching tabs that have a title from the frontmatter the title is being lost (rewritten to a `file.basename`). This PR fixes this problem.