### PR TITLE
update title for externally created files

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -140,6 +140,11 @@ export default class MetaTitlePlugin extends Plugin implements PluginInterface {
                     this.dispatcher.dispatch("file:rename", new Event({ old, actual }))
                 )
             );
+            this.registerEvent(
+                // after workspace.onLayoutReady, "create" is only called for new files.
+                // (it's called for *all* files on startup, before layout is ready.)
+                this.app.vault.on("create", ({ path }) => this.mc.update(path).catch(console.error))
+            );
             await new Promise(r => setTimeout(r, 3000));
             this.reloadFeatures();
             await this.mc.refresh();


### PR DESCRIPTION
Resolves #250.

I tested this locally by:
 1. Installing my fork of the plugin on desktop, and reloading the window
 2. Creating a file from another device, which gets synced to the running desktop instance via Obsidian Sync

When the new file landed on desktop, it successfully updated the title in the File Explorer.