### PR TITLE
Feature: Abbreviations

### DIFF
--- a/config/services/feature.config.ts
+++ b/config/services/feature.config.ts
@@ -8,6 +8,7 @@ import ManagerComposer from "@src/Feature/ManagerComposer";
 import SearchFeature from "@src/Feature/Search/SearchFeature";
 import TabManager from "@src/Feature/Tab/TabManager";
 import { AliasFeature } from "@src/Feature/Alias/AliasFeature";
+import AbbreviationsFeature from "@src/Feature/Abbreviations/AbbreviationsFeature";
 import EnsureStrategy from "@src/Feature/Alias/Strategy/EnsureStrategy";
 import AdjustStrategy from "@src/Feature/Alias/Strategy/AdjustStrategy";
 import ReplaceStrategy from "@src/Feature/Alias/Strategy/ReplaceStrategy";
@@ -58,6 +59,10 @@ export default (container: Container) => {
             return feature;
         });
     container.bind<FeatureInterface<any>>(SI.feature).to(AliasFeature).whenTargetNamed(AliasFeature.getId());
+    container
+        .bind<FeatureInterface<any>>(SI.feature)
+        .to(AbbreviationsFeature)
+        .whenTargetNamed(AbbreviationsFeature.getId());
     container
         .bind<FeatureInterface<any>>(SI.feature)
         .to(WindowFrameFeature)

--- a/config/services/settings.config.ts
+++ b/config/services/settings.config.ts
@@ -14,9 +14,11 @@ import RulesPathsBuilder from "@src/Settings/SettingBuilders/Rules/RulesPathsBui
 import ProcessorBuilder from "../../src/Settings/SettingBuilders/Processor/ProcessorBuilder";
 import NoteLinkBuilder from "@src/Settings/FeatureBuilder/NoteLinkBuilder";
 import ExplorerBuilder from "@src/Settings/FeatureBuilder/ExplorerBuilder";
+import { Feature as F } from "@src/Enum";
 
 export default (c: Container) => {
     c.bind(SI["settings:feature:builder"]).to(DefaultBuilder).whenTargetNamed("default");
+    c.bind(SI["settings:feature:builder"]).to(DefaultBuilder).whenTargetNamed(F.Abbreviations);
     c.bind(SI["settings:feature:builder"])
         .to(AliasBuilder)
     .whenTargetNamed(Feature.Alias);

--- a/main.ts
+++ b/main.ts
@@ -82,7 +82,7 @@ export default class MetaTitlePlugin extends Plugin implements PluginInterface {
         const delay = this.storage.get("boot").get("delay").value();
         const background = this.storage.get("boot").get("background").value();
         this.logger.log(`Plugin manual delay ${delay}`);
-        let promise = new Promise(r =>
+        let promise = new Promise<void>(r =>
             setTimeout(() => {
                 this.fc = Container.get(SI["feature:composer"]);
                 this.mc = Container.get(SI["manager:composer"]);
@@ -93,7 +93,9 @@ export default class MetaTitlePlugin extends Plugin implements PluginInterface {
         );
         if (delay > 0) {
             new Notice(`[${this.manifest.name}]\nWill be loaded in ${delay}ms. Background: ${background}`);
-            promise = promise.then(() => new Notice(`[${this.manifest.name}]\nLoaded. Background: ${background}`));
+            promise = promise.then(() => {
+                new Notice(`[${this.manifest.name}]\nLoaded. Background: ${background}`);
+            });
         }
         return background ? null : promise;
     }
@@ -163,6 +165,13 @@ export default class MetaTitlePlugin extends Plugin implements PluginInterface {
         }
 
         for (const [id, state] of states) {
+            // Enforce Abbreviations only when Alias is enabled
+            if (id === Feature.Abbreviations) {
+                const aliasEnabled = this.storage.get("features").get(Feature.Alias).get("enabled").value();
+                if (!aliasEnabled) {
+                    continue;
+                }
+            }
             try {
                 this.fc.toggle(id, state as boolean);
             } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,13 +54,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -198,9 +199,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -208,9 +209,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -227,14 +228,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -327,13 +328,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.28.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -534,27 +535,24 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -590,15 +588,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2494,9 +2491,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2817,9 +2814,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3568,9 +3565,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5459,9 +5456,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5797,9 +5794,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6180,12 +6177,6 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
       "license": "Apache-2.0"
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -6724,16 +6715,6 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/src/Enum.ts
+++ b/src/Enum.ts
@@ -23,6 +23,7 @@ export enum Feature {
     Search = Leaves.S,
     Tab = "tab",
     Alias = "alias",
+    Abbreviations = "abbreviations",
     Suggest = "suggest",
     InlineTitle = "inlineTitle",
     Canvas = "canvas",

--- a/src/Feature/Abbreviations/AbbreviationsFeature.ts
+++ b/src/Feature/Abbreviations/AbbreviationsFeature.ts
@@ -1,0 +1,102 @@
+import { inject, injectable, named } from "inversify";
+import SI from "@config/inversify.types";
+import LoggerInterface from "@src/Components/Debug/LoggerInterface";
+import { Feature } from "@src/Enum";
+import { CachedMetadata, MetadataCacheExt } from "obsidian";
+import { MetadataCacheFactory } from "@config/inversify.factory.types";
+import AbstractFeature from "@src/Feature/AbstractFeature";
+import EventDispatcherInterface from "@src/Components/EventDispatcher/Interfaces/EventDispatcherInterface";
+import { AppEvents } from "@src/Types";
+import ListenerRef from "@src/Components/EventDispatcher/Interfaces/ListenerRef";
+import Alias from "@src/Feature/Alias/Alias";
+import FeatureService from "@src/Feature/FeatureService";
+import { ResolverInterface } from "@src/Resolver/Interfaces";
+
+@injectable()
+export default class AbbreviationsFeature extends AbstractFeature<Feature> {
+    private enabled = false;
+    private ref: ListenerRef<"metadata:cache:changed"> = null;
+    private resolver: ResolverInterface;
+
+    constructor(
+        @inject(SI.logger)
+        @named("abbreviations")
+        private logger: LoggerInterface,
+        @inject(SI["factory:metadata:cache"]) private factory: MetadataCacheFactory<MetadataCacheExt>,
+        @inject(SI["event:dispatcher"]) private dispatcher: EventDispatcherInterface<AppEvents>,
+        @inject(SI["feature:config"]) @named(Feature.Abbreviations) private config: { key?: string },
+        @inject(SI["feature:service"]) private featureService: FeatureService
+    ) {
+        super();
+        this.resolver = this.featureService.createResolver(Feature.Abbreviations);
+    }
+
+    static getId(): Feature {
+        return Feature.Abbreviations;
+    }
+
+    disable(): void {
+        this.dispatcher.removeListener(this.ref);
+        this.ref = null;
+        this.enabled = false;
+    }
+
+    enable(): void {
+        // Only enable when Alias feature is active (enforced in main reloadFeatures)
+        this.ref = this.dispatcher.addListener({
+            name: "metadata:cache:changed",
+            cb: e => this.update(e.get().path, e.get().cache),
+        });
+        this.enabled = true;
+        this.refresh().catch(console.error);
+    }
+
+    getId(): Feature {
+        return AbbreviationsFeature.getId();
+    }
+
+    isEnabled(): boolean {
+        return this.enabled;
+    }
+
+    private process(frontmatter: { [k: string]: any }, path: string): boolean {
+        // debug: process frontmatter keys
+        const alias = new Alias(frontmatter);
+        // Resolve abbreviation via templates (main/fallback)
+        const value = this.resolver.resolve(path);
+        if (!value) return false;
+        let current = alias.getValue() ?? [];
+        if (!Array.isArray(current)) current = [current];
+        const values: string[] = Array.isArray(value) ? value : [value];
+        for (const v of values) {
+            if (!current.includes(v)) {
+                current.push(v);
+            }
+        }
+        alias.setValue(current);
+        // debug: aliases after
+        return alias.isChanged();
+    }
+
+    private async update(path: string, metadata: CachedMetadata = null): Promise<void> {
+        if (!metadata?.frontmatter) {
+            // debug: skip: no frontmatter
+            return;
+        }
+        // debug: update path
+        const changed = this.process(metadata.frontmatter, path);
+        if (changed) {
+            this.logger.log(`Abbreviations updated for ${path}`);
+            // debug: updated for path
+        }
+    }
+
+    private async refresh(): Promise<void> {
+        const cache = this.factory();
+        const promises = [] as Promise<void>[];
+        for (const path of cache.getCachedFiles()) {
+            promises.push(this.update(path, cache.getCache(path)));
+        }
+        await Promise.all(promises);
+    }
+}

--- a/src/Settings/SettingBuilders/Features/FeaturesBuilder.ts
+++ b/src/Settings/SettingBuilders/Features/FeaturesBuilder.ts
@@ -12,6 +12,7 @@ import { t } from "@src/i18n/Locale";
 @injectable()
 export default class FeaturesBuilder extends AbstractBuilder<SettingsType, "features"> {
     private ref: ListenerRef<"settings:tab:feature:changed"> = null;
+    private sectionEl: HTMLElement;
 
     constructor(
         @inject(SI["factory:settings:feature:builder"])
@@ -30,9 +31,16 @@ export default class FeaturesBuilder extends AbstractBuilder<SettingsType, "feat
 
     doBuild(): void {
         this.bind();
-        this.container.createEl("h4", { text: t("features") });
+        // Create an isolated section container so we don't wipe the whole settings tab
+        this.sectionEl = this.container.createDiv();
+        this.render();
+    }
+
+    private render(): void {
+        this.sectionEl.empty();
+        this.sectionEl.createEl("h4", { text: t("features") });
         const data: { feature: Feature; name: string; desc: string; doc: { link: string } }[] = this.helper
-            .getOrderedFeatures()
+            .getVisibleFeatures(this.item.value())
             .map(feature => ({
                 desc: this.helper.getDescription(feature),
                 feature,
@@ -47,7 +55,7 @@ export default class FeaturesBuilder extends AbstractBuilder<SettingsType, "feat
             const builder = this.builderFactory(item.feature) ?? this.builderFactory("default");
             const settings = this.item.get(item.feature).value();
             builder.setContext({
-                getContainer: () => this.container,
+                getContainer: () => this.sectionEl,
                 getSettings: () => this.item.value(),
                 getDispatcher: () => this.dispatcher,
             });
@@ -58,7 +66,11 @@ export default class FeaturesBuilder extends AbstractBuilder<SettingsType, "feat
     private bind(): void {
         this.ref = this.dispatcher.addListener({
             name: "settings:tab:feature:changed",
-            cb: e => this.item.get(e.get().id).set(e.get().value),
+            cb: e => {
+                this.item.get(e.get().id).set(e.get().value);
+                // Immediately re-render features list so visibility changes (e.g., Abbreviations) apply
+                this.render();
+            },
         });
         this.dispatcher.addListener({
             name: "settings:tab:close",

--- a/src/Utils/FeatureHelper.ts
+++ b/src/Utils/FeatureHelper.ts
@@ -19,13 +19,24 @@ export default class FeatureHelper {
             Feature.Backlink,
             Feature.NoteLink,
             Feature.WindowFrame,
+            // Abbreviations will be injected conditionally by getVisibleFeatures
         ];
+    }
+
+    getVisibleFeatures(settings: any): Feature[] {
+        const features = this.getOrderedFeatures();
+        if (settings?.alias?.enabled) {
+            features.splice(1, 0, Feature.Abbreviations);
+        }
+        return features;
     }
 
     getName(feature: Feature): string {
         switch (feature) {
             case Feature.Alias:
                 return t("feature.alias.name");
+            case Feature.Abbreviations:
+                return t("feature.abbreviations.name");
             case Feature.Explorer:
                 return t("feature.explorer.name");
             case Feature.Graph:
@@ -57,6 +68,8 @@ export default class FeatureHelper {
         switch (feature) {
             case Feature.Alias:
                 return t("feature.alias.desc");
+            case Feature.Abbreviations:
+                return t("feature.abbreviations.desc");
             case Feature.Explorer:
                 return t("feature.explorer.desc");
             case Feature.Graph:

--- a/src/Utils/PluginHelper.ts
+++ b/src/Utils/PluginHelper.ts
@@ -49,6 +49,7 @@ export default class PluginHelper {
                     validator: ValidatorType.FrontmatterRequired,
                     templates: { main: "", fallback: "" },
                 },
+                [Feature.Abbreviations]: { enabled: false, templates: { main: "", fallback: "" } },
                 [Feature.Explorer]: { enabled: false, sort: false, templates: { main: "", fallback: "" } },
                 [Feature.Tab]: { enabled: false, templates: { main: "", fallback: "" } },
                 [Feature.Header]: { enabled: false, templates: { main: "", fallback: "" } },

--- a/src/i18n/en/index.ts
+++ b/src/i18n/en/index.ts
@@ -35,6 +35,10 @@ const en = {
                 },
             },
         },
+        [Feature.Abbreviations]: {
+            name: "Abbreviations",
+            desc: "Add an additional abbreviation value to the aliases metadata cache.",
+        },
         [Feature.Explorer]: {
             name: "Explorer",
             desc: "Replace shown titles in the file explorer",


### PR DESCRIPTION
# Feature: Abbreviations

This PR adds a new feature to this plugin called Abbreviations. When enabled, an additional frontmatter field can be supplied to be added as an alias to the metadata cache. I added this feature because I wanted to separate the Abbreviations into a separate frontmatter field, as opposed to just being added into `aliases`, to improve the clarity of my notes, but I still wanted them to be used as an alias.

<img width="814" height="470" alt="image" src="https://github.com/user-attachments/assets/d399a71a-13cc-4ad8-b0b4-57e90bc1f5db" />

<img width="814" height="470" alt="image" src="https://github.com/user-attachments/assets/1761888b-d908-46de-9790-a00c2b318ce9" />

<img width="814" height="479" alt="image" src="https://github.com/user-attachments/assets/5a059ef3-ffd8-47ed-afc7-4c8c1c4bfeb9" />

<img width="814" height="598" alt="image" src="https://github.com/user-attachments/assets/4d9d8d8f-3aed-49b6-a652-f9d21159a4f8" />

Some changes to the rendering logic were made as well, to only display this feature when the Alias feature has been turned on.