### PR TITLE
FIX: [Bug] After switching workspace which contains locked tabs, the program interface is blank #251

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -82,7 +82,7 @@ export default class MetaTitlePlugin extends Plugin implements PluginInterface {
         const delay = this.storage.get("boot").get("delay").value();
         const background = this.storage.get("boot").get("background").value();
         this.logger.log(`Plugin manual delay ${delay}`);
-        let promise = new Promise(r =>
+        let promise = new Promise<void>(r =>
             setTimeout(() => {
                 this.fc = Container.get(SI["feature:composer"]);
                 this.mc = Container.get(SI["manager:composer"]);
@@ -93,7 +93,7 @@ export default class MetaTitlePlugin extends Plugin implements PluginInterface {
         );
         if (delay > 0) {
             new Notice(`[${this.manifest.name}]\nWill be loaded in ${delay}ms. Background: ${background}`);
-            promise = promise.then(() => new Notice(`[${this.manifest.name}]\nLoaded. Background: ${background}`));
+            promise = promise.then(() => {new Notice(`[${this.manifest.name}]\nLoaded. Background: ${background}`);});
         }
         return background ? null : promise;
     }

--- a/src/Feature/Tab/TabManager.ts
+++ b/src/Feature/Tab/TabManager.ts
@@ -77,7 +77,9 @@ export default class TabManager extends AbstractManager {
             function (self, [pinned], vanilla) {
                 const result = vanilla.call(this, pinned);
                 if (this?.view?.getViewType() === Leaves.MD) {
-                    self.innerUpdate(this.view.file.path);
+                    if ((this?.view?.file ?? null) != null) {
+                        self.innerUpdate(this.view.file.path);
+                    }
                 }
                 return result;
             }


### PR DESCRIPTION
FIX issue #251: `TypeError: Cannot read properties of undefined (reading 'path').`
Details: only call `innerUpdate` when `this.view.file.path` is defined.

I could reproduce the error with a workspace and a pinned tab.
The error shows up in the dev tools console.

In addition, small fix in `main.ts` due to the following errors while running `npm run build` (environment: node v22.12.0):

- main.ts:91:17 - error TS2794: Expected 1 arguments, but got 0. Did you forget to include 'void' in your type argument to 'Promise'?
- main.ts:96:13 - error TS2322: Type 'Promise<void | Notice>' is not assignable to type 'Promise<void>'.
