### PR TITLE
Only show loading notifications when Debug mode is active

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -81,8 +81,9 @@ export default class MetaTitlePlugin extends Plugin implements PluginInterface {
     private async delay(): Promise<void> {
         const delay = this.storage.get("boot").get("delay").value();
         const background = this.storage.get("boot").get("background").value();
+        const debug = this.storage.get("debug").value();
         this.logger.log(`Plugin manual delay ${delay}`);
-        let promise = new Promise(r =>
+        let promise = new Promise<void>(r =>
             setTimeout(() => {
                 this.fc = Container.get(SI["feature:composer"]);
                 this.mc = Container.get(SI["manager:composer"]);
@@ -91,9 +92,11 @@ export default class MetaTitlePlugin extends Plugin implements PluginInterface {
                 r();
             }, delay)
         );
-        if (delay > 0) {
+        if (delay > 0 && debug) {
             new Notice(`[${this.manifest.name}]\nWill be loaded in ${delay}ms. Background: ${background}`);
-            promise = promise.then(() => new Notice(`[${this.manifest.name}]\nLoaded. Background: ${background}`));
+            promise = promise.then(() => {
+                new Notice(`[${this.manifest.name}]\nLoaded. Background: ${background}`);
+            });
         }
         return background ? null : promise;
     }


### PR DESCRIPTION
Hi @snezhig!

Hope you don’t mind this unsolicited PR.

I’ve only just migrated from Evernote to Obsidian, and love this plugin, which has enabled me to keep using special characters like slashes and colons in my note titles ❤️

But I was annoyed by the "Loading" notifications on startup. So I modified the code, locally, to disable them. 

Then I realised other people (@mrmodest @huyz) had [reported the same issue too](https://github.com/snezhig/obsidian-front-matter-title/issues/270), so figured I’d contribute a fix for everyone.

With the changes in this PR, the loading notifications that were introduced in version 3.13.1 will now only be displayed at startup if the "Debug" setting is enabled in the Front Matter Title settings window.

I hope you think this is a useful contribution. I’ve run the tests and the linter and they all pass, and I’ve verified the plugin still works locally, for me, with Debug enabled and disabled. But please do let me know if you’d like me to make any changes to the commit before you’re happy to merge it.

Fixes #270.