### PR TITLE
Add #h1..#h6 placeholders for level-specific titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ compare link. Headings must be `## X.Y.Z` (the version, no `v`) so CI can find t
 
 At release time, rename `## Unreleased` to the version being released.
 
+## Unreleased
+
+### Added
+- `#h1`..`#h6` template placeholders: use the first heading of a specific level as
+  the title (e.g. `#h1` uses the H1 only). `#heading` still matches the first heading
+  of any level. Compose a fallback like `#h1|_basename`.
+
 ## 4.1.1
 
 ### Fixed

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -42,7 +42,8 @@ book:
 
 Beyond frontmatter keys, a template can pull from:
 
-- **`#heading`** — the first heading in the note.
+- **`#heading`** — the first heading in the note (any level).
+- **`#h1`, `#h2`, … `#h6`** — the first heading of that exact level. `#h1` uses the H1 only.
 - **`_basename`** — a field from Obsidian's file info (the `_` prefix). `_basename` is the filename without extension; other [TFile](https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts) fields work too.
 
 **"Or" logic with `|`** — try several keys, use the first non‑empty one:
@@ -93,3 +94,4 @@ In the **Templates** section:
 | Title, or the note's first heading if there's no title | `title\|#heading` |
 | Title, or status if there's no title | `title\|status` |
 | Use the first heading as the title | `#heading` |
+| Use only the H1 as the title (or fallback if no H1 exists) | `#h1` |

--- a/src/Creator/Template/Placeholders/Factory.ts
+++ b/src/Creator/Template/Placeholders/Factory.ts
@@ -16,7 +16,7 @@ export default class Factory {
             type = AbstractPlaceholder.BRACKETS;
         } else if (placeholder.startsWith("_")) {
             type = AbstractPlaceholder.FILE;
-        } else if (placeholder === "#heading") {
+        } else if (placeholder === "#heading" || /^#h[1-6]$/.test(placeholder)) {
             type = AbstractPlaceholder.HEADING;
         } else if (placeholder.includes("|")) {
             type = AbstractPlaceholder.LOGIC;

--- a/src/Creator/Template/Placeholders/HeadingPlaceholder.ts
+++ b/src/Creator/Template/Placeholders/HeadingPlaceholder.ts
@@ -13,6 +13,15 @@ export default class HeadingPlaceholder extends AbstractPlaceholder {
     }
 
     makeValue(path: string): string {
-        return this.factory(path, "headings")?.[0]?.heading ?? "";
+        const headings = this.factory(path, "headings") ?? [];
+        const match = this.placeholder.match(/^#h([1-6])$/);
+        if (match) {
+            const level = Number(match[1]);
+            const found = headings.find(
+                (h: { level: number; heading: string }) => h.level === level
+            );
+            return found?.heading ?? "";
+        }
+        return headings[0]?.heading ?? "";
     }
 }


### PR DESCRIPTION
  ## What

  Adds `#h1`..`#h6` template placeholders that resolve to the first heading of a
  specific level, alongside the existing `#heading`.

  ## Why

  `#heading` returns the first heading of *any* level, so a note without an H1
  falls through to its H2/H3. Some setups want to pin the title to one level --
  e.g. use the H1 only, and fall back to the filename when there is no H1.
  Requested in #286.
  
  ## Behaviour
  
  - `#h1`..`#h6` -> the first heading of that exact level.
  - When that level is absent, the placeholder resolves to empty, so the normal
    resolution chain applies (fallback template, then the original filename).
  - `#heading` is unchanged (first heading, any level).
  
  Example: `#h1` shows the note's H1; remove the H1 and the title falls back to the
  filename instead of leaking an H2.
  
  ## Implementation
  
  - Reuses the existing `HEADING` placeholder type and its DI binding -- no new
    inversify bindings and no new `PlaceholderType`.
  - `Factory` routes `#h1`..`#h6` (via `^#h[1-6]$`) to `HEADING`.
  - `HeadingPlaceholder` reads the level from its own token and returns the first
    matching heading. Placeholders are transient-scoped, so reading the token per
    instance is safe. 
  - Purely additive and fully backward compatible.
  
  ## Tests
  
  - Adds `HeadingPlaceholder.spec.ts` (this placeholder had no spec), covering
    `#heading` (any level) and `#h1`/`#h3`/`#h4`, including the "no such level"
    fallback-to-empty case.                                                                
                                     
  ## Docs
                                                                                           
  - `docs/Templates.md`: documents `#h1`..`#h6` and adds a recipe row.                     
  - `CHANGELOG.md`: entry under `Unreleased`.                                              
  
  Closes #286
